### PR TITLE
fixed typo on integration/prometheus page

### DIFF
--- a/website/docs/integrations/prometheus.md
+++ b/website/docs/integrations/prometheus.md
@@ -176,7 +176,7 @@ spec:
       - litmus
   podMetricsEndpoints:
     - port: tcp
-    - interval: 1s
+      interval: 1s
       metricRelabelings:
         - targetLabel: instance
           replacement: 'chaos-exporter-service'


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed typo for the podMonitor example under the "Prometheus community version (helm) - kube-prometheus-stack with pod monitor" section. Original podMonitor configuration will scrap the metric from all the pods which port is TCP and the pod with target label. Update the podMetricsEndpoints to only scrape the metric from the target pod in the PodMonitor yaml file.

**Checklist:**
-   [x] Fixes #143 
-   [x] Signed the commit for DCO to be passed
-   [x] Labelled this PR & related issue with `documentation` tag
