### PR TITLE
Add reference to Glossary in Notes section of Chaos Execution Plane doc

### DIFF
--- a/website/docs/architecture/chaos-execution-plane.md
+++ b/website/docs/architecture/chaos-execution-plane.md
@@ -68,4 +68,7 @@ With the latest release of LitmusChaos 3.0.0:
 - The term **Chaos Delegate/Agent** has been changed to **Chaos Infrastructure**.
 - The term **Chaos Experiment** has been changed to **Chaos Fault**.
 - The term **Chaos Scenario/Workflow** has been changed to **Chaos Experiment**.
+
+Refer to the [Glossary](https://docs.litmuschaos.io/docs/next/glossary) doc for more info.
+
 :::

--- a/website/docs/architecture/chaos-execution-plane.md
+++ b/website/docs/architecture/chaos-execution-plane.md
@@ -69,6 +69,6 @@ With the latest release of LitmusChaos 3.0.0:
 - The term **Chaos Experiment** has been changed to **Chaos Fault**.
 - The term **Chaos Scenario/Workflow** has been changed to **Chaos Experiment**.
 
-Refer to the [Glossary](https://docs.litmuschaos.io/docs/next/glossary) doc for more info.
+Refer to the [Glossary](../glossary.md) doc for more info.
 
 :::


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**: 
The Chaos Execution Plane documentation includes a Notes section but does not provide links to additional resources.
So, aded reference to Glossary in Notes section of Chaos Execution Plane doc

**Which issue this PR fixes** : #372 

**Checklist:**
-   [x] Fixes #372
-   [x] Signed the commit for DCO to be passed
