### PR TITLE
[documentation] Badal/fix issue 375

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-<img alt="LitmusChaos" src="https://avatars.githubusercontent.com/u/49853472?s=200&v=4" width="200" align="left">
-
 # Documentation for the Litmus Project
+
+<img alt="LitmusChaos" src="https://avatars.githubusercontent.com/u/49853472?s=200&v=4" width="200" align="left">
 
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Flitmuschaos%2Flitmus-docs.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Flitmuschaos%2Flitmus-docs?ref=badge_shield)
 [![Slack Channel](https://img.shields.io/badge/Slack-Join-purple)](https://slack.litmuschaos.io)
@@ -59,7 +59,9 @@ _Check the difference:_
 - Executing `embedmd -d docs-name.md` will display the difference between the contents of docs-name.md and the output of embedmd docs-name.md.
 
 ## Manual Setup
+
 ### Pre-Requisites
+
 - Node.js 16.14 or above. It can be installed from [here](https://nodejs.org/en/download/).
 
 ### Start the server


### PR DESCRIPTION
**What this PR does / why we need it**:

fixes #375 

**Special notes for your reviewer**:
Github by default adds the underline for the main headings and thats why it was visible. Using manual span with same header size instead of markdown `#`

**Checklist:**
-   [x] Fixes #375
-   [x] Signed the commit for DCO to be passed
-   [ ] Labelled this PR & related issue with `documentation` tag

**Testing**
<img width="860" height="318" alt="image" src="https://github.com/user-attachments/assets/a4fb73d6-74c8-4244-854d-984857fd9e96" />

