### PR TITLE
[documentation] update the logo and make readme header cleaner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 <div align="center">
-  <img alt="LitmusChaos" src="https://litmuschaos.io/logos/dark-logo.svg" width="200">
+
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://litmuschaos.io/logos/light-logo.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://litmuschaos.io/logos/dark-logo.svg">
+    <img alt="LitmusChaos" src="https://litmuschaos.io/logos/dark-logo.svg" width="200">
+  </picture>
 
   <h1 style="margin-top: 20px; margin-bottom: 10px;">Documentation for the Litmus project</h1>
+
 </div>
 
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Flitmuschaos%2Flitmus-docs.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Flitmuschaos%2Flitmus-docs?ref=badge_shield)

--- a/README.md
+++ b/README.md
@@ -65,9 +65,7 @@ _Check the difference:_
 - Executing `embedmd -d docs-name.md` will display the difference between the contents of docs-name.md and the output of embedmd docs-name.md.
 
 ## Manual Setup
-
 ### Pre-Requisites
-
 - Node.js 16.14 or above. It can be installed from [here](https://nodejs.org/en/download/).
 
 ### Start the server

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-<img alt="LitmusChaos" src="https://avatars.githubusercontent.com/u/49853472?s=200&v=4" width="200" align="left">
+<div align="center">
+  <img alt="LitmusChaos" src="https://litmuschaos.io/logos/dark-logo.svg" width="200">
 
-# Documentation for the Litmus Project
+  <h1 style="margin-top: 20px; margin-bottom: 10px;">Documentation for the Litmus project</h1>
+</div>
 
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Flitmuschaos%2Flitmus-docs.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Flitmuschaos%2Flitmus-docs?ref=badge_shield)
 [![Slack Channel](https://img.shields.io/badge/Slack-Join-purple)](https://slack.litmuschaos.io)
@@ -19,8 +21,6 @@
 [FR](translations/README-fr.md)
 
 Additional details on the Docusaurus project can be found [here](https://docusaurus.io/docs/en/installation.html).
-
-#
 
 ## For Developers
 
@@ -59,7 +59,9 @@ _Check the difference:_
 - Executing `embedmd -d docs-name.md` will display the difference between the contents of docs-name.md and the output of embedmd docs-name.md.
 
 ## Manual Setup
+
 ### Pre-Requisites
+
 - Node.js 16.14 or above. It can be installed from [here](https://nodejs.org/en/download/).
 
 ### Start the server


### PR DESCRIPTION
**What this PR does / why we need it**:

fixes #374 

**Special notes for your reviewer**:

**Checklist:**
-   [x] Fixes #374
-   [x] Signed the commit for DCO to be passed
-   [x] Labelled this PR & related issue with `documentation` tag

I have updated the logo to the new one and have reformatted the readme title to accomodate the new logo

### Attached below is the new Logo, you can switch the modes to light and dark to visualize it:

<div align="center">

  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://litmuschaos.io/logos/light-logo.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://litmuschaos.io/logos/dark-logo.svg">
    <img alt="LitmusChaos" src="https://litmuschaos.io/logos/dark-logo.svg" width="200">
  </picture>

  <h1 style="margin-top: 20px; margin-bottom: 10px;">Documentation for the Litmus project</h1>

</div>
