### PR TITLE
replaced chaoscenter with Resiliance Probes

### DIFF
--- a/website/docs/concepts/visualize-experiment.md
+++ b/website/docs/concepts/visualize-experiment.md
@@ -12,7 +12,7 @@ Visualization is an important aspect while doing chaos engineering. It allows th
 
 The following is required before visualizing a chaos experiment:
 
-- ChaosCenter
+- [Resilience Probes](probes.md)
 - [Chaos Experiments](chaos-workflow.md)
 
 ## Create chaos experiment


### PR DESCRIPTION
docs: replace ChaosCenter with Resilience Probes in visualize-experiment prerequisites

Replaced 'ChaosCenter' with 'Resilience Probes' under the Prerequisite section of website/docs/concepts/visualize-experiment.md. Ensured link formatting is consistent and ran embedmd to update embedded snippets.

Fixes #<issue-number>
Signed-off-by: Abhijith Sai Chinni <abhijithsai9@gmail.com>

