### PR TITLE
Add overview to ChaosCenter Developer Guide documentation

### DIFF
--- a/website/docs/concepts/visualize-experiment.md
+++ b/website/docs/concepts/visualize-experiment.md
@@ -12,7 +12,7 @@ Visualization is an important aspect while doing chaos engineering. It allows th
 
 The following is required before visualizing a chaos experiment:
 
-- ChaosCenter
+- [Resilience Probes](probes.md)
 - [Chaos Experiments](chaos-workflow.md)
 
 ## Create chaos experiment

--- a/website/docs/developer-guide/chaoscenter-developer-guide.md
+++ b/website/docs/developer-guide/chaoscenter-developer-guide.md
@@ -6,7 +6,6 @@ sidebar_label: ChaosCenter Developer Guide
 
 ---
 
-## **Overview**
 ChaosCenter is the control plane for LitmusChaos, providing a web-based interface and APIs to manage chaos experiments on Kubernetes clusters. It consists of a backend (GraphQL server, Authentication server, MongoDB) and a frontend (React) component. This guide walks you through setting up ChaosCenter locally, running the required services, and connecting your Kubernetes infrastructure to execute and monitor chaos experiments.
 
 The document assumes a local development environment and is not recommended for production or shared clusters. By the end of this guide, you will have a fully functional ChaosCenter instance capable of managing chaos workflows and integrating with Litmusctl or ChaosCenter-managed infrastructures.

--- a/website/docs/developer-guide/chaoscenter-developer-guide.md
+++ b/website/docs/developer-guide/chaoscenter-developer-guide.md
@@ -6,6 +6,11 @@ sidebar_label: ChaosCenter Developer Guide
 
 ---
 
+## **Overview**
+ChaosCenter is the control plane for LitmusChaos, providing a web-based interface and APIs to manage chaos experiments on Kubernetes clusters. It consists of a backend (GraphQL server, Authentication server, MongoDB) and a frontend (React) component. This guide walks you through setting up ChaosCenter locally, running the required services, and connecting your Kubernetes infrastructure to execute and monitor chaos experiments.
+
+The document assumes a local development environment and is not recommended for production or shared clusters. By the end of this guide, you will have a fully functional ChaosCenter instance capable of managing chaos workflows and integrating with Litmusctl or ChaosCenter-managed infrastructures.
+
 ## **Prerequisites**
 :::note
 This document is intended to be implemented locally. Please do not use in dev or prod environments.


### PR DESCRIPTION
docs: Add overview to ChaosCenter Developer Guide documentation

Added "Overview" in the ChaosCenter Develper Guide documentation above prerequuisite. Ensured to add the given content in isssue.

Fixes #360 
Signed-off-by: Abhijith Sai Chinni <abhijithsai9@gmail.com>