### PR TITLE
Updated proper subheadings and references in Resources doc

### DIFF
--- a/website/docs/getting-started/resources.md
+++ b/website/docs/getting-started/resources.md
@@ -13,19 +13,25 @@ ChaosCenter comes pre-packaged as a part of LitmusChaos installation and can be 
 
 ChaosCenter gives you access to a plethora of features, the major ones include:
 
-- **Chaos experiment creation**
+- ### Chaos experiment creation
   - From templates, custom experiments from scratch (using ChaosHubs), from pre-created YAMLs
   - Experiments sequence control (parallel as well as sequential steps creation)
   - Creation of either singular or cron experiments as schedules
   - Attaching priority to experiments based on your use cases
-- **Users and teams**
+
+  To learn more, check out the [Chaos Experiment documentation](../concepts/chaos-workflow.md)
+- ### Users and teams
   - Creation of users with Role Based Access Control
   - Creating a team of multiple users
   - Authenticating users
-- **Chaos experiment management**
+
+  To learn more, check out the [Teaming documentation](../concepts/teaming.md)
+- ### Chaos experiment management
   - Rolling out automated changes using GitOps
   - Allowing image addition from custom image server (both public and private)
   - Measure and analyze the Resilience Score of each chaos scenario
+
+  To learn more, check out the [GitOps documentation](../concepts/gitops.md)
 
 ## Chaos Infrastructures
 Chaos infrastructure is a service that runs in your target environment and aids Litmus in accessing and injecting chaos to your target environment. There should always be at least one or more than one chaos infrastructure connected to the ChaosCenter to execute an experiment.
@@ -34,6 +40,8 @@ Chaos infrastructure is a service that runs in your target environment and aids 
 
 In Litmus, chaos infrastructures can be classified into two types:
 
-- **Self Chaos Infrastructures:** A Chaos Infrastructure that is connected to the same cluster and namespace where the ChaosCenter is deployed. It can be used to target the workloads executing on that cluster only.
+- ### Self Chaos Infrastructures
+  A Chaos Infrastructure that is connected to the same cluster and namespace where the ChaosCenter is deployed. It can be used to target the workloads executing on that cluster only.
 
-- **External Chaos Infrastructures:** A Chaos Infrastructure that is connected to a remote Kubernetes cluster. ChaosCenter can be operated in a cross-cloud manner, which allows connecting multiple External Chaos Infrastructure to the same ChaosCenter with the help of the [litmusctl](../litmusctl/installation.md) CLI. Once connected you can manage, monitor, observe and induce chaos from the ChaosCenter to the respective External Chaos Infrastructures.
+- ### External Chaos Infrastructures
+  A Chaos Infrastructure that is connected to a remote Kubernetes cluster. ChaosCenter can be operated in a cross-cloud manner, which allows connecting multiple External Chaos Infrastructure to the same ChaosCenter with the help of the [litmusctl](../litmusctl/installation.md) CLI. Once connected you can manage, monitor, observe and induce chaos from the ChaosCenter to the respective External Chaos Infrastructures.

--- a/website/docs/getting-started/resources.md
+++ b/website/docs/getting-started/resources.md
@@ -13,25 +13,27 @@ ChaosCenter comes pre-packaged as a part of LitmusChaos installation and can be 
 
 ChaosCenter gives you access to a plethora of features, the major ones include:
 
-- ### Chaos experiment creation
-  - From templates, custom experiments from scratch (using ChaosHubs), from pre-created YAMLs
-  - Experiments sequence control (parallel as well as sequential steps creation)
-  - Creation of either singular or cron experiments as schedules
-  - Attaching priority to experiments based on your use cases
+### Chaos experiment creation
+- From templates, custom experiments from scratch (using ChaosHubs), from pre-created YAMLs
+- Experiments sequence control (parallel as well as sequential steps creation)
+- Creation of either singular or cron experiments as schedules
+- Attaching priority to experiments based on your use cases
 
-  To learn more, check out the [Chaos Experiment documentation](../concepts/chaos-workflow.md)
-- ### Users and teams
-  - Creation of users with Role Based Access Control
-  - Creating a team of multiple users
-  - Authenticating users
+To learn more, check out the [Chaos Experiment documentation](../concepts/chaos-workflow.md)
 
-  To learn more, check out the [Teaming documentation](../concepts/teaming.md)
-- ### Chaos experiment management
-  - Rolling out automated changes using GitOps
-  - Allowing image addition from custom image server (both public and private)
-  - Measure and analyze the Resilience Score of each chaos scenario
+### Users and teams
+- Creation of users with Role Based Access Control
+- Creating a team of multiple users
+- Authenticating users
 
-  To learn more, check out the [GitOps documentation](../concepts/gitops.md)
+To learn more, check out the [Teaming documentation](../concepts/teaming.md)
+
+### Chaos experiment management
+- Rolling out automated changes using GitOps
+- Allowing image addition from custom image server (both public and private)
+- Measure and analyze the Resilience Score of each chaos scenario
+
+To learn more, check out the [GitOps documentation](../concepts/gitops.md)
 
 ## Chaos Infrastructures
 Chaos infrastructure is a service that runs in your target environment and aids Litmus in accessing and injecting chaos to your target environment. There should always be at least one or more than one chaos infrastructure connected to the ChaosCenter to execute an experiment.
@@ -40,8 +42,8 @@ Chaos infrastructure is a service that runs in your target environment and aids 
 
 In Litmus, chaos infrastructures can be classified into two types:
 
-- ### Self Chaos Infrastructures
-  A Chaos Infrastructure that is connected to the same cluster and namespace where the ChaosCenter is deployed. It can be used to target the workloads executing on that cluster only.
+### Self Chaos Infrastructures
+A Chaos Infrastructure that is connected to the same cluster and namespace where the ChaosCenter is deployed. It can be used to target the workloads executing on that cluster only.
 
-- ### External Chaos Infrastructures
-  A Chaos Infrastructure that is connected to a remote Kubernetes cluster. ChaosCenter can be operated in a cross-cloud manner, which allows connecting multiple External Chaos Infrastructure to the same ChaosCenter with the help of the [litmusctl](../litmusctl/installation.md) CLI. Once connected you can manage, monitor, observe and induce chaos from the ChaosCenter to the respective External Chaos Infrastructures.
+### External Chaos Infrastructures
+A Chaos Infrastructure that is connected to a remote Kubernetes cluster. ChaosCenter can be operated in a cross-cloud manner, which allows connecting multiple External Chaos Infrastructure to the same ChaosCenter with the help of the [litmusctl](../litmusctl/installation.md) CLI. Once connected you can manage, monitor, observe and induce chaos from the ChaosCenter to the respective External Chaos Infrastructures.


### PR DESCRIPTION
#369 Update subheadings and references in Resources documentation

Updated the subheadings of Chaos Center section and Types of Chaos Infrastructure section. 
Added reference links in Under Chaos Experiment Creation, Users and teams and Under Chaos experiment management.