### PR TITLE
Restructured contribute section in community doc

### DIFF
--- a/website/docs/introduction/community.md
+++ b/website/docs/introduction/community.md
@@ -68,15 +68,13 @@ Find publicly available Chaos Experiments at [ChaosHub](http://hub.litmuschaos.i
 
 Read about [chaos experiments](https://litmuschaos.github.io/litmus/).
 
-## Contribute
+## Contribute to Litmus
 
 We invite contributions in all forms. Join us in writing blogs on [Dev.to](https://dev.to/t/litmuschaos/latest) about experiments, features, and your experience. Use the `#litmuschaos` tag for your post to be featured.
 
 Participation in the Litmus community is governed by our [code of conduct](https://github.com/litmuschaos/litmus/blob/master/CODE_OF_CONDUCT.md).
 
-### Contribute to Litmus open source
-
-See the Litmus [contribution document](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md).
+Checkout the [contribution guide](../../../CONTRIBUTING.md).
 
 Contributors meet twice a month. See [Contributor meetings](#contributor-meetings).
 

--- a/website/docs/introduction/community.md
+++ b/website/docs/introduction/community.md
@@ -74,7 +74,7 @@ We invite contributions in all forms. Join us in writing blogs on [Dev.to](https
 
 Participation in the Litmus community is governed by our [code of conduct](https://github.com/litmuschaos/litmus/blob/master/CODE_OF_CONDUCT.md).
 
-Checkout the [contribution guide](../../../CONTRIBUTING.md).
+Checkout the [contribution guide](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md).
 
 Contributors meet twice a month. See [Contributor meetings](#contributor-meetings).
 


### PR DESCRIPTION
#353 Restructure “Contribute” section in Community docs

Updated the following in Contribute section:
1. Merged the contents of Contribute and Contribute to Litmus open source sections under a single heading "Contribute to Litmus".
2. Replaced the sentence
"See the Litmus contribution document" to Checkout the [contribution guide](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md).