### PR TITLE
docs: add missing hyperlink for "Chaos Schedule" #349

### DIFF
--- a/website/docs/introduction/features.md
+++ b/website/docs/introduction/features.md
@@ -73,5 +73,5 @@ Litmus 3.0 culminates as well as enhances the features rolled-out through Litmus
 ## Learn more
 - [Install Litmus](../getting-started/installation.md)
 - [Visualize Chaos Experiments](../concepts/visualize-experiment.md)
-- Chaos Schedule
+- [Chaos Schedule](../user-guides/schedule-experiment.md)
 - [View the different User Guides](../user-guides/overview.md)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a hyperlink for "Chaos Schedule" pointing to its detailed documentation page in the Features doc.

**Which issue this PR fixes**:
fixes #349

**Checklist**:
- [x] Fixes #349 
- [x] Signed the commit for DCO to be passed
- [ ] Labelled this PR & related issue with 'documentation' tag