### PR TITLE
Fix: Remove “Check out more resources about Litmus” from Learn More section in Uses of Litmus documentation

### DIFF
--- a/website/docs/introduction/usage.md
+++ b/website/docs/introduction/usage.md
@@ -29,4 +29,3 @@ Chaos Engineering is a culture-oriented practice. With time, management buying a
 - [Understand the Core Principles of Litmus](core-principles.md)
 - [Be a part of the Community](community.md)
 - [Get Started with Litmus](../getting-started/installation.md)
-- [Check out more resources about Litmus](other-links.md)


### PR DESCRIPTION
Remove “Check out more resources about Litmus” from Learn More section in Uses of Litmus documentation

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Removes the unnecessary line “Check out more resources about Litmus” from the Learn More section in the Uses of Litmus documentation. This text was redundant as it linked out to the community page, which is already accessible elsewhere and was not needed in this section.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #351

**Special notes for your reviewer**:
N/A

**Checklist:**
-   [x] Fixes #351
-   [x] Signed the commit for DCO to be passed
-   [x] Labelled this PR & related issue with `documentation` tag
