### PR TITLE
Removed stray parentheses

### DIFF
--- a/website/docs/user-guides/chaoscenter-oauth-dex-installation.md
+++ b/website/docs/user-guides/chaoscenter-oauth-dex-installation.md
@@ -163,8 +163,8 @@ Go to http://litmusportal-frontend-service/auth/dex/login, you should be prompte
 
 ## Learn more
 
-- [Install ChaosCenter with HTTP](../getting-started/installation.md))
-- [Install ChaosCenter with HTTPS](chaoscenter-advanced-installation.md))
+- [Install ChaosCenter with HTTP](../getting-started/installation.md)
+- [Install ChaosCenter with HTTPS](chaoscenter-advanced-installation.md)
 - [Connect External Chaos Delegates to ChaosCenter](../user-guides/chaos-infrastructure-installation.md)
 - [Setup Endpoints and Access ChaosCenter without Ingress](../user-guides/setup-without-ingress.md)
 - [Setup Endpoints and Access ChaosCenter with Ingress](../user-guides/setup-with-ingress.md)

--- a/website/docs/user-guides/setup-with-ingress.md
+++ b/website/docs/user-guides/setup-with-ingress.md
@@ -154,5 +154,5 @@ kubectl apply -f <litmus_ingress_manifest> -n <PORTAL_NAMESPACE>
 ## Learn more
 
 - [Setup Endpoints and Access ChaosCenter without Ingress](setup-without-ingress.md)
-- [Install ChaosCenter with HTTP](../getting-started/installation.md))
+- [Install ChaosCenter with HTTP](../getting-started/installation.md)
 - [Install ChaosCenter with HTTPS](chaoscenter-advanced-installation.md)

--- a/website/docs/user-guides/setup-without-ingress.md
+++ b/website/docs/user-guides/setup-without-ingress.md
@@ -10,7 +10,7 @@ sidebar_label: Setup without ingress
 
 Before setting up endpoint without Ingress, make sure [ChaosCenter](../getting-started/resources.md#chaoscenter) is installed in either one of these scopes:
 
-- [Install ChaosCenter with HTTP](../getting-started/installation.md))
+- [Install ChaosCenter with HTTP](../getting-started/installation.md)
 - [Install ChaosCenter with HTTPS](chaoscenter-advanced-installation.md)
 
 ## NodePort service setup
@@ -76,5 +76,5 @@ By default you are assigned with a default project with Owner permissions.
 ## Learn more
 
 - [Setup Endpoints and Access ChaosCenter with Ingress](setup-with-ingress.md)
-- [Install ChaosCenter with HTTP](../getting-started/installation.md))
+- [Install ChaosCenter with HTTP](../getting-started/installation.md)
 - [Install ChaosCenter with HTTPS](chaoscenter-advanced-installation.md)


### PR DESCRIPTION
#347 Remove extra “)” in user guide under Advanced Installation → ChaosCenter

Updated the following sections by removing extra ")"
1. Learn More section of [OAuth2 Supporting using Dex](https://docs.litmuschaos.io/docs/next/user-guides/chaoscenter-oauth-dex-installation) doc
2. Prerequisite and Learn More sections of [Setting up endpoints without ingress](https://docs.litmuschaos.io/docs/next/user-guides/setup-without-ingress) doc
3. Learn More section of [Setup with ingress](https://docs.litmuschaos.io/docs/next/user-guides/setup-with-ingress) doc