### PR TITLE
fix(readme): remove underline below the main title

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
     <img alt="LitmusChaos" src="https://litmuschaos.io/logos/dark-logo.svg" width="200">
   </picture>
 
-  <h1 style="margin-top: 20px; margin-bottom: 10px;">Documentation for the Litmus project</h1>
+  <h1 style="margin-top: 20px; margin-bottom: 10px; border-bottom: none;">Documentation for the Litmus project</h1>
 
 </div>
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the underline (which is a default `border-bottom` style) from the main title in the `README.md` file.

**Which issue this PR fixes**
fixes #375 

**Checklist:**
-   [x] Fixes #375 
-   [x] Signed the commit for DCO to be passed
-   [ ] Labelled this PR & related issue with `documentation` tag
