### PR TITLE
docs: add AVX CPU requirement for MongoDB

### DIFF
--- a/website/versioned_docs/version-3.23.0/getting-started/installation.md
+++ b/website/versioned_docs/version-3.23.0/getting-started/installation.md
@@ -18,6 +18,8 @@ Recommend to have a Persistent volume(PV) of 20GB, You can start with 1GB for te
 
 - [Helm3](https://v3.helm.sh/) or [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
 
+- **Hardware Requirement:** Ensure your CPU supports **AVX instructions**. MongoDB (used by Litmus) requires AVX; older processors (e.g., some Celeron/Pentium models) may cause the MongoDB pod to crash loop.
+
 ## Installation
 
 Users looking to use Litmus for the first time have two options available to them today. One way is to use a hosted Litmus service like [Harness Chaos Engineering SaaS](https://app.harness.io/auth/#/signin). Alternatively, users looking for some more flexibility can install Litmus into their own Kubernetes cluster.


### PR DESCRIPTION
**What this PR does / why we need it**:
Added a note about AVX CPU requirements for MongoDB in the installation guide. This prevents crashes on older hardware (e.g., Pentium/Celeron) that lack AVX support, as MongoDB 5.0+ requires it.

**Which issue this PR fixes**:
fixes litmuschaos/litmus#5357

**Special notes for your reviewer**:
None.

**Checklist:**
-   [x] Fixes litmuschaos/litmus#5357
-   [x] Signed the commit for DCO to be passed
-   [ ] Labelled this PR & related issue with `documentation` tag